### PR TITLE
✨ Add websocket server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const express = require('express');
 const bodyParser = require('body-parser');
 const { MongoClient } = require('mongodb');
+const WebSocket = require('ws');
 
 const {
   NODE_ENV: ENV = 'development',
@@ -49,4 +50,12 @@ MongoClient.connect(MONGODB_URI, {
   let server = app.listen(PORT, () => {
     console.log(`App now running on http://localhost:${server.address().port}`);
   });
+
+  // Initialize websockets.
+  let wss = app.locals.wss = {};
+  wss.v1 = new WebSocket.Server({ server, path: '/v1' });
+  wss.send = (v, data) => {
+    let message = JSON.stringify(data);
+    wss[v].clients.forEach(ws => ws.send(message));
+  };
 });

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,8 @@
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "mongodb": "^3.5.5",
-    "node-github-graphql": "^0.2.7"
+    "node-github-graphql": "^0.2.7",
+    "ws": "^7.2.3"
   },
   "devDependencies": {
     "nodemon": "^2.0.2"

--- a/server/v1/routes.js
+++ b/server/v1/routes.js
@@ -17,6 +17,7 @@ router.post('/collect', function(req, res) {
     if (err) {
       handleError(res, err.message, 'Failed to create new weather data point.');
     } else {
+      req.app.locals.wss.send('v1', doc.ops[0]);
       res.status(201).json(doc.ops[0]);
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8706,6 +8706,11 @@ ws@^6.1.0:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
+  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
+
 ws@~3.3.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"


### PR DESCRIPTION
## Purpose

Get live updates as the weather station posts data to the API

## Approach

Add a versioned websocket server so respective server versions can send different data. When new websocket server versions are created, they all cannot share the same http server. To have the websocket servers share a http server, we have to [handle the upgrade event manually](https://github.com/websockets/ws#multiple-servers-sharing-a-single-https-server).

When a websocket connects to the `v1` route it will receive a message anytime the `v1/collect` endpoint updates the database.

This also effectively acts as a heartbeat. If the weather station does not update the endpoint for some time, the frontend can reasonably assume the station is down (or just no longer talking to the `v1` endpoint).