### PR TITLE
Add `.env` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist/
+server/.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 dist/
-server/.env
+.env

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const path = require('path');
 const { URL } = require('url');
 const express = require('express');

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "mongodb": "^3.5.5",
     "node-github-graphql": "^0.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,7 +2964,7 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^8.1.0:
+dotenv@^8.1.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==


### PR DESCRIPTION
I got tired of setting the prod mongo db env var. So now I'll write it to a file
and never need to again