### PR TITLE
🐛 Fix websocket upgrade url handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const { URL } = require('url');
 const express = require('express');
 const bodyParser = require('body-parser');
 const { MongoClient } = require('mongodb');
@@ -62,7 +61,7 @@ MongoClient.connect(MONGODB_URI, {
 
   // Handle websocket versioning.
   server.on('upgrade', (request, socket, head) => {
-    let v = new URL(request.url).pathname.substr(1);
+    let v = request.url.substr(1);
 
     if (wss[v]) {
       wss[v].handleUpgrade(request, socket, head, (ws) => {


### PR DESCRIPTION
## Purpose

The [example on the `ws` page](https://github.com/websockets/ws#multiple-servers-sharing-a-single-https-server) was a little outdated. Not only does it use `url.parse` (deprecated), but the `request.url` property does not need to be parsed in our situation.

## Approach

The `url.parse` deprecation was already accounted for (#203), but the `request.url` property wasn't updated.